### PR TITLE
READMEファイルのインフラ構築手順の見出し削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## インフラ構築手順書  
 
-- ### [VPC構築](/doc/setup-of-VPC.md)
+- [VPC構築](/doc/setup-of-VPC.md)
 
 ## ライセンス
 


### PR DESCRIPTION
## 対応内容

READMEファイルの見出しを整える修正

## やったこと

1.READMEファイルの「インフラ構築手順」パス欄にある見出し記述「###」を削除し、箇条書きのみに変更

以下レビューに対応するため、既にマージ済みですが、再マージの依頼になります。
【独自ドメインをRoute53に登録する手順書の作成】
https://github.com/dokugaku-engineer/DailyReport/pull/15

![image](https://user-images.githubusercontent.com/89679815/147046230-4cf6e2ca-bf03-4a41-b1f6-09fc5c814786.png)


## やってないこと

上記以外